### PR TITLE
Use Model Input and Predicted Feature Name

### DIFF
--- a/DiscreetAI/CoreMLClient/CoreMLUtils.swift
+++ b/DiscreetAI/CoreMLClient/CoreMLUtils.swift
@@ -59,3 +59,17 @@ func saveUpdatedModel(_ model: MLModel & MLWritable, to url: URL) throws {
         throw DMLError.coreMLError(ErrorMessage.failedModelUpdate)
     }
 }
+
+/**
+ Get the input and predicted feature name from the model.
+ 
+ - Parameters:
+    - model: The model to train with.
+ 
+ - Returns: A length-2 tuple consisting of the input name and the predicted feature name.
+ */
+func getModelNames(model: MLModel) -> (String, String) {
+    let trainingInputs =  Array(model.modelDescription.trainingInputDescriptionsByName.keys)
+    let inputName = model.modelDescription.inputDescriptionsByName.keys.first!
+    return inputName == trainingInputs[0] ? (trainingInputs[0], trainingInputs[1]) : (trainingInputs[1], trainingInputs[0])
+}

--- a/DiscreetAI/CoreMLClient/Image/ImageBatchProvider.swift
+++ b/DiscreetAI/CoreMLClient/Image/ImageBatchProvider.swift
@@ -23,6 +23,12 @@ class ImagesBatchProvider: MLBatchProvider {
     /// The constraints of the input image.
     var imageConstraint: MLImageConstraint
     
+    /// The name of the input .
+    var inputName: String
+    
+    /// The name of the predicted feature.
+    var predictedFeatureName: String
+    
     /// The number of datapoints.
     var count: Int
 
@@ -33,12 +39,16 @@ class ImagesBatchProvider: MLBatchProvider {
         - realmClient: instance of RealmClient to get data from.
         - datasetID: The dataset ID corresponding to the desired dataset.
         - imageConstraint: The constraints of the input image.
+        - inputName: The name of the input .
+        - predictedFeatureName: The name of the predicted feature.
     */
-    init(realmClient: RealmClient, datasetID: String, imageConstraint: MLImageConstraint) {
+    init(realmClient: RealmClient, datasetID: String, imageConstraint: MLImageConstraint, inputName: String, predictedFeatureName: String) {
         let imageEntry = realmClient.getImageEntry(datasetID: datasetID)!
         (self.images, self.labels) = imageEntry.getData()
         self.count = self.images.count
         self.imageConstraint = imageConstraint
+        self.inputName = inputName
+        self.predictedFeatureName = predictedFeatureName
     }
 
     /**
@@ -50,6 +60,6 @@ class ImagesBatchProvider: MLBatchProvider {
      - Returns: A `ImageFeatureProvider` corresponding ot the image path and label.
     */
     func features(at index: Int) -> MLFeatureProvider {
-        return try! ImagesFeatureProvider(image: self.images[index], label: self.labels[index], imageConstraint: self.imageConstraint)
+        return try! ImagesFeatureProvider(image: self.images[index], label: self.labels[index], imageConstraint: self.imageConstraint, inputName: inputName, predictedFeatureName: predictedFeatureName)
     }
 }

--- a/DiscreetAI/CoreMLClient/Image/ImageFeatureProvider.swift
+++ b/DiscreetAI/CoreMLClient/Image/ImageFeatureProvider.swift
@@ -20,10 +20,16 @@ class ImagesFeatureProvider: MLFeatureProvider {
     /// The corresponding label for this image.
     var label: String
     
+    /// The name of the input .
+    var inputName: String
+    
+    /// The name of the predicted feature.
+    var predictedFeatureName: String
+    
     /// The possible feature names. Currently just the input image and label.
     var featureNames: Set<String> {
         get {
-            return ["image", "label"]
+            return [inputName, predictedFeatureName]
         }
     }
     
@@ -36,10 +42,10 @@ class ImagesFeatureProvider: MLFeatureProvider {
      - Returns: An optional consisting of the desired feature or `nil`.
     */
     func featureValue(for featureName: String) -> MLFeatureValue? {
-        if (featureName == "image") {
+        if (featureName == inputName) {
             return MLFeatureValue(pixelBuffer: image)
         }
-        if (featureName == "label") {
+        if (featureName == predictedFeatureName) {
             return MLFeatureValue(string: label)
         }
         return nil
@@ -52,10 +58,12 @@ class ImagesFeatureProvider: MLFeatureProvider {
         - image: The path to the image within the documents directory.
         - label: The corresponding label for this datapoint
         - imageConstraint: The constraints of the input image.
+        - inputName: The name of the input .
+        - predictedFeatureName: The name of the predicted feature.
      
      - Throws: `DMLError` if the image could not be loaded from the provided path.
     */
-    init(image: String, label: String, imageConstraint: MLImageConstraint) throws {
+    init(image: String, label: String, imageConstraint: MLImageConstraint, inputName: String, predictedFeatureName: String) throws {
         let imageURL = makeImageURL(image: image)
         let imageOptions: [MLFeatureValue.ImageOption: Any] = [:]
         var featureValue: MLFeatureValue
@@ -68,5 +76,7 @@ class ImagesFeatureProvider: MLFeatureProvider {
         }
         self.image = featureValue.imageBufferValue!
         self.label = label
+        self.inputName = inputName
+        self.predictedFeatureName = predictedFeatureName
     }
 }

--- a/DiscreetAI/CoreMLClient/Text/TextBatchProvider.swift
+++ b/DiscreetAI/CoreMLClient/Text/TextBatchProvider.swift
@@ -21,6 +21,12 @@ class TextBatchProvider: MLBatchProvider {
     /// The labels for each of the text datapoints.
     var labels: [Int]
     
+    /// The name of the input .
+    var inputName: String
+    
+    /// The name of the predicted feature.
+    var predictedFeatureName: String
+    
     /// The number of datapoints.
     var count: Int
     
@@ -30,11 +36,15 @@ class TextBatchProvider: MLBatchProvider {
      - Parameters:
         - realmClient: instance of RealmClient to get data from.
         - datasetID: The dataset ID corresponding to the desired dataset.
+        - inputName: The name of the input .
+        - predictedFeatureName: The name of the predicted feature.
      */
-    init(realmClient: RealmClient, datasetID: String) {
+    init(realmClient: RealmClient, datasetID: String, inputName: String, predictedFeatureName: String) {
         let textEntry = realmClient.getTextEntry(datasetID: datasetID)!
         (self.encodings, self.labels) = textEntry.getData()
         self.count = self.encodings.count
+        self.inputName = inputName
+        self.predictedFeatureName = predictedFeatureName
     }
     
     /**
@@ -48,6 +58,6 @@ class TextBatchProvider: MLBatchProvider {
     func features(at index: Int) -> MLFeatureProvider {
         let textDatapoint = self.encodings[index]
         let label = self.labels[index]
-        return TextFeatureProvider(textDatapoint: textDatapoint, label: label)
+        return TextFeatureProvider(textDatapoint: textDatapoint, label: label, inputName: inputName, predictedFeatureName: predictedFeatureName)
     }
 }

--- a/DiscreetAI/CoreMLClient/Text/TextFeatureProvider.swift
+++ b/DiscreetAI/CoreMLClient/Text/TextFeatureProvider.swift
@@ -20,10 +20,16 @@ class TextFeatureProvider : MLFeatureProvider {
     /// The corresponding label as an MLMultiArray.
     var label: MLMultiArray
     
+    /// The name of the input .
+    var inputName: String
+    
+    /// The name of the predicted feature.
+    var predictedFeatureName: String
+    
     /// The possible feature names. Currently just the input text datapoint and label.
     var featureNames: Set<String> {
         get {
-            return ["input.1", "14_true"]
+            return [inputName, predictedFeatureName]
         }
     }
     
@@ -36,10 +42,10 @@ class TextFeatureProvider : MLFeatureProvider {
      - Returns: An optional consisting of the desired feature or `nil`.
      */
     func featureValue(for featureName: String) -> MLFeatureValue? {
-        if (featureName == "input.1") {
+        if (featureName == inputName) {
             return MLFeatureValue(multiArray: self.textDatapoint)
         }
-        if (featureName == "14_true") {
+        if (featureName == predictedFeatureName) {
             return MLFeatureValue(multiArray: self.label)
         }
         return nil
@@ -51,9 +57,13 @@ class TextFeatureProvider : MLFeatureProvider {
      - Parameters:
         - textDatapoint: The 1D array of encoded text data.
         - label: The corresponding label for this datapoint
+        - inputName: The name of the input .
+        - predictedFeatureName: The name of the predicted feature.
      */
-    init(textDatapoint: [Int], label: Int) {
+    init(textDatapoint: [Int], label: Int, inputName: String, predictedFeatureName: String) {
         self.textDatapoint = MLMultiArray.from(textDatapoint, dims: 2)
         self.label = MLMultiArray.from([label])
+        self.inputName = inputName
+        self.predictedFeatureName = predictedFeatureName
     }
 }


### PR DESCRIPTION
Instead of relying upon the cloud node to convert the model with a specific input and predicted feature name, just parse the model description to get these values. 

Necessary since the user so that the user does not have to specify any names from Explora.